### PR TITLE
Fix broken link in system design documentation

### DIFF
--- a/public/SYSTEM_DESIGN.md
+++ b/public/SYSTEM_DESIGN.md
@@ -171,4 +171,4 @@
 
 ---
 
-*Want to understand how this works in practice? Check out [How XP Works →](/how-xp-works)*
+*Want to understand how this works in practice? Check out [How XP Works →](/docs?doc=how-xp-works)*


### PR DESCRIPTION
## Summary
Fixed the broken "How XP Works" link in the system design documentation that was returning a 404 error.

## Changes
- Updated link from `/how-xp-works` to `/docs?doc=how-xp-works` in `public/SYSTEM_DESIGN.md`

Fixes #3